### PR TITLE
pass utf-8 as file encoding to gradle jvm

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
fixes
```
> Task :compileJava
D:\tmp\replicate\src\main\java\replicate\net\requestwaitinglist\RequestWaitingList.java:31: error: unmappable character (0x90) for encoding windows-1252
 *       ΓöîΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓö?  ΓöîΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓö?  ΓöîΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓö?
```
on windows.